### PR TITLE
Ensure data is set when calling setRules

### DIFF
--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -446,6 +446,10 @@
     QueryBuilder.prototype.setRules = function(data) {
         this.clear();
 
+        if (!data || !data.rules || data.rules.length==0) {
+            $.error('Incorrect data object passed');
+        }
+
         var $container = this.$el,
             that = this;
 
@@ -453,10 +457,6 @@
             var $group = that.addGroup($container, false),
                 $ul = $group.find('>.rules-group-body>.rules-list'),
                 $buttons = $group.find('>.rules-group-header input[name$=_cond]');
-
-            if (typeof data === 'undefined' || (!data || !data.rules)) {
-                return false;
-            }
 
             if (!data.condition) {
                 data.condition = that.settings.default_condition;


### PR DESCRIPTION
Thanks for all your work so far, Damien.

I am dynamically creating and destroying a QueryBuilder, and as part of that, I am filling in the previous rules. This normally works OK, apart from when I completely empty the rules.

When the rules are completely emptied, and I run something similar to this:

```
 _rules = $('#builder').queryBuilder('getRules');
 // do some work with rules... reload a table...
 // the rules are empty
 $('#builder').queryBuilder('setRules', _rules);
```

I get an error come up in the Chrome console, and nothing works.

```
  TypeError: Cannot read property 'length' of undefined
```

This resolves this issue, by checking that the `data` variable is actually defined, and that there are actually some rules to process.
