### PR TITLE
JSON maps are unordered by default. Added support for arrays of maps to ...

### DIFF
--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -1215,16 +1215,24 @@
 
         switch (filter.input) {
             case 'radio':
-                c = filter.vertical ? ' class=block' : '';
+            	c = filter.vertical ? ' class=block' : '';
                 if ($.isArray(filter.values)) {
-                    $.each(filter.values, function(index, entry) {
-                    	$.each(entry, function(key, val) {
-                    		h+= '<label'+ c +'><input type="radio" name="'+ rule_id +'_value" value="'+ key +'"> '+ val +'</label> ';
-                    		return false; // break after first entry
-                    	});
-                    });
+                	$.each(filter.values, function(index, entry) {
+	                	if ($.type(entry) == 'string') {
+	                		// list of strings (for backwards compatibility)
+	                		h+= '<label'+ c +'><input type="radio" name="'+ rule_id +'_value" value="'+ index +'"> '+ entry +'</label> ';
+	                	}
+	                	else {
+	                		// list of one-element maps
+	                    	$.each(entry, function(key, val) {
+	                    		h+= '<label'+ c +'><input type="radio" name="'+ rule_id +'_value" value="'+ key +'"> '+ val +'</label> ';
+	                    		return false; // break after first entry
+	                    	});
+                		}
+                	});
             	}
             	else {
+            		// unordered map of option entries
                 	$.each(filter.values, function(key, val) {
                 		h+= '<label'+ c +'><input type="radio" name="'+ rule_id +'_value" value="'+ key +'"> '+ val +'</label> ';
                 	});
@@ -1232,16 +1240,24 @@
                 break;
 
             case 'checkbox':
-                c = filter.vertical ? ' class=block' : '';
+            	c = filter.vertical ? ' class=block' : '';
                 if ($.isArray(filter.values)) {
                     $.each(filter.values, function(index, entry) {
-                    	$.each(entry, function(key, val) {
-                    		h+= '<label'+ c +'><input type="checkbox" name="'+ rule_id +'_value" value="'+ key +'"> '+ val +'</label> ';
-                    		return false; // break after first entry
-                    	});
+                    	if ($.type(entry) == 'string') {
+                    		// list of strings (for backwards compatibility)
+                    		h+= '<label'+ c +'><input type="checkbox" name="'+ rule_id +'_value" value="'+ index +'"> '+ entry +'</label> ';
+                    	}
+                    	else {
+                    		// list of one-element maps
+	                    	$.each(entry, function(key, val) {
+	                    		h+= '<label'+ c +'><input type="checkbox" name="'+ rule_id +'_value" value="'+ key +'"> '+ val +'</label> ';
+	                    		return false; // break after first entry
+	                    	});
+                    	}
                     });
             	}
             	else {
+            		// unordered map of option entries
                 	$.each(filter.values, function(key, val) {
                 		h+= '<label'+ c +'><input type="checkbox" name="'+ rule_id +'_value" value="'+ key +'"> '+ val +'</label> ';
                 	});
@@ -1249,17 +1265,25 @@
                 break;
 
             case 'select':
-                h+= '<select name="'+ rule_id +'_value"'+ (filter.multiple ? ' multiple' : '') +'>';
+            	h+= '<select name="'+ rule_id +'_value"'+ (filter.multiple ? ' multiple' : '') +'>';
                 if (filter.values) {
                 	if ($.isArray(filter.values)) {
 	                    $.each(filter.values, function(index, entry) {
-	                    	$.each(entry, function(key, val) {
-	                    		h+= '<option value="'+ key +'"> '+ val +'</option> ';
-	                    		return false; // break after first entry
-	                    	});
+	                    	if ($.type(entry) == 'string') {
+	                    		// list of strings (for backwards compatibility)
+	                    		h+= '<option value="'+ index +'"> '+ entry +'</option> ';
+	                    	}
+	                    	else {
+	                    		// list of one-element maps
+		                    	$.each(entry, function(key, val) {
+		                    		h+= '<option value="'+ key +'"> '+ val +'</option> ';
+		                    		return false; // break after first entry
+		                    	});
+	                    	}
 	                    });
                 	}
                 	else {
+                		// unordered map of option entries
                     	$.each(filter.values, function(key, val) {
                     		h+= '<option value="'+ key +'"> '+ val +'</option> ';
                     	});


### PR DESCRIPTION
...provide a means to ensure ordered values while also specifing the keys.

Backwards compatibility is maintained.
Values can be specified in three ways now:

values only (backwards compatible) -->
values: {
 value1,
 value2,
 ...
}

unordered with user-defined keys -->
values: {
 key1:value1,
 key2:value2,
...
}

ordered with user-defined keys -->
values: [
{key1:value1},
{key2:value2},
...
]
