### PR TITLE
builder not working with unique-filter and filter id with dots

### DIFF
--- a/src/plugins/unique-filter/plugin.js
+++ b/src/plugins/unique-filter/plugin.js
@@ -49,12 +49,12 @@ QueryBuilder.extend({
         // disable some
         $.each(self.status.used_filters, function(filterId, groups) {
             if (groups.length === 0) {
-                self.$el.find('.rule-filter-container option[value=' + filterId + ']:not(:selected)').prop('disabled', true);
+                self.$el.find('.rule-filter-container option[value="' + filterId + '"]:not(:selected)').prop('disabled', true);
             }
             else {
                 groups.forEach(function(group) {
                     group.each(function(rule) {
-                        rule.$el.find('.rule-filter-container option[value=' + filterId + ']:not(:selected)').prop('disabled', true);
+                        rule.$el.find('.rule-filter-container option[value="' + filterId + '"]:not(:selected)').prop('disabled', true);
                     });
                 });
             }


### PR DESCRIPTION
After adding `unique-filter` and selecting filter, plugin stops working because filter `id` have dot in it. Of course it can be avoided by changing `id` to something else and adding `field` attribute, but since everything else is working fine with such `id` the `unique-filter` can be fixed.

    filters: [{
        id: 'object.name',
        label: 'Name',
        type: 'string'
    }]