### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "jquery": ">= 1.9.0",
     "bootstrap": "^3.1.0",
-    "momentjs": "^2.6.0",
+    "moment": "^2.6.0",
     "jquery-extendext": "^0.1.1"
   },
   "devDependencies": {

--- a/tests/index.html
+++ b/tests/index.html
@@ -22,7 +22,7 @@
   <script src="../bower_components/bootstrap/dist/js/bootstrap.min.js"></script>
   <script src="../bower_components/bootstrap-select/dist/js/bootstrap-select.min.js"></script>
   <script src="../bower_components/bootbox/bootbox.js"></script>
-  <script src="../bower_components/momentjs/min/moment.min.js"></script>
+  <script src="../bower_components/moment/min/moment.min.js"></script>
   <script src="../bower_components/jquery-extendext/jQuery.extendext.min.js"></script>
 
   <script src="common.js"></script>


### PR DESCRIPTION
>
https://github.com/moment/momentjs.com/pull/116
> >
The "momentjs.com"-Library changed their Bower-Registry-Name from "momentjs" to "moment". For consistency, all external libraries should use the new Name.