### PR TITLE
bypass step validation when step is 'any'

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -139,7 +139,7 @@ QueryBuilder.prototype.validateValueInternal = function(rule, value) {
                                 break;
                             }
                         }
-                        if (validation.step !== undefined) {
+                        if (validation.step !== undefined && validation.step !== 'any') {
                             var v = value[i]/validation.step;
                             if (parseInt(v) != v) {
                                 result = ['number_wrong_step', validation.step];


### PR DESCRIPTION
Step attribute can take `any` as value - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-step