### PR TITLE
Typeahead Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bower_components
 node_modules
 .sass-cache
 .coverage-results
+*.swp

--- a/examples/bower.json
+++ b/examples/bower.json
@@ -3,6 +3,7 @@
   "dependencies" : {
     "seiyria-bootstrap-slider": "latest",
     "bootswatch-dist": "#slate",
-    "selectize": "latest"
+    "selectize": "latest",
+    "bootstrap3-typeahead": "https://github.com/bassjobsen/Bootstrap-3-Typeahead.git#master"
   }
 }

--- a/examples/index.html
+++ b/examples/index.html
@@ -98,6 +98,7 @@
 <script src="../bower_components/bootbox/bootbox.js"></script>
 <script src="bower_components/seiyria-bootstrap-slider/dist/bootstrap-slider.min.js"></script>
 <script src="bower_components/selectize/dist/js/standalone/selectize.min.js"></script>
+<script src="bower_components/bootstrap3-typeahead/bootstrap3-typeahead.min.js"></script>
 <script src="../bower_components/jquery-extendext/jQuery.extendext.min.js"></script>
 <script src="../bower_components/sql-parser/browser/sql-parser.js"></script>
 <script src="../bower_components/doT/doT.js"></script>
@@ -128,7 +129,8 @@ var options = {
     'bt-selectpicker': null,
     'unique-filter': null,
     'bt-checkbox': { color: 'primary' },
-    'invert': null
+    'invert': null,
+    'bootstrap3-typeahead': { minLength: 2 }
   },
 
   filters: [
@@ -305,6 +307,18 @@ var options = {
     operators: ['equal', 'not_equal'],
     validation: {
       format: /^.{4}-.{4}-.{4}$/
+    }
+  },
+  /*
+   * typeahead
+   */
+  {
+    id: 'colour',
+    label: 'Colour',
+    optgroup: 'plugin',
+    type: 'string',
+    typeahead: {
+      source: [ 'Red', 'Green', 'Blue' ]
     }
   },
   /*

--- a/src/plugins/bootstrap3-typeahead/plugin.js
+++ b/src/plugins/bootstrap3-typeahead/plugin.js
@@ -1,0 +1,26 @@
+/*!
+ * jQuery QueryBuilder Typeahead Description
+ * Extends text input fields to provide typeahead options
+ */
+
+/**
+ * @throws ConfigError
+ */
+QueryBuilder.define( 'bootstrap3-typeahead', function(options) {
+    this.on('afterCreateRuleInput', function(e, rule) {
+        if (rule.__.filter.typeahead) {
+            var inputField = '#' + rule.id + ' .rule-value-container .form-control';
+            var $inputField = $(inputField);
+
+            // we need Bootstrap-3-Typeahead
+            if (!('typeahead' in $inputField)) {
+                Utils.error('MissingLibrary', 'Bootstrap-3-Typeahead is not loaded. Get it here https://github.com/bassjobsen/Bootstrap-3-Typeahead/');
+            }
+
+            var allOptions = $.extend({}, options, rule.__.filter.typeahead);
+
+            $inputField.attr('autocomplete', 'off');
+            $inputField.typeahead(allOptions);
+        }
+    });
+} );


### PR DESCRIPTION
Bootstrap-3-Typeahead provides typeahead suggestions for text input fields.  Users can either choose a suggestion or enter arbitrary text:
https://github.com/bassjobsen/Bootstrap-3-Typeahead/