### PR TITLE
Non-sortable groups

### DIFF
--- a/src/plugins/sortable/plugin.js
+++ b/src/plugins/sortable/plugin.js
@@ -106,13 +106,13 @@ QueryBuilder.define('sortable', function(options) {
     /**
      * Remove drag handle from non-sortable groups
      */
-    this.on('parseGroupFlags.filter', function (flags) {
+    this.on('parseGroupFlags.filter', function(flags) {
         if (flags.value.no_sortable === undefined) {
             flags.value.no_sortable = options.default_no_sortable;
         }
     });
 
-    this.on('afterApplyGroupFlags', function (e, group) {
+    this.on('afterApplyGroupFlags', function(e, group) {
         if (group.flags.no_sortable) {
             group.$el.find('.drag-handle').remove();
         }

--- a/src/plugins/sortable/plugin.js
+++ b/src/plugins/sortable/plugin.js
@@ -104,6 +104,21 @@ QueryBuilder.define('sortable', function(options) {
     });
 
     /**
+     * Remove drag handle from non-sortable groups
+     */
+    this.on('parseGroupFlags.filter', function (flags) {
+        if (flags.value.no_sortable === undefined) {
+            flags.value.no_sortable = options.default_no_sortable;
+        }
+    });
+
+    this.on('afterApplyGroupFlags', function (e, group) {
+        if (group.flags.no_sortable) {
+            group.$el.find('.drag-handle').remove();
+        }
+    });
+
+    /**
      * Modify templates
      */
     this.on('getGroupTemplate.filter', function(h, level) {


### PR DESCRIPTION
If you set the "no_sortable" flag of a group to true the sort group drag handle is removed.
This is the same behaviour of non-sortable rules.