### PR TITLE
Fix using setFilters() does not trigger "afterUpdateRuleFilter"

### DIFF
--- a/src/plugins/change-filters/plugin.js
+++ b/src/plugins/change-filters/plugin.js
@@ -53,6 +53,7 @@ QueryBuilder.extend({
                       self.createRuleFilters(rule);
 
                       rule.$el.find(Selectors.rule_filter).val(rule.filter ? rule.filter.id : '-1');
+                      self.trigger('afterUpdateRuleFilter', rule);
                   }
               },
               updateBuilder


### PR DESCRIPTION
Because of the way DOM elements are updated in place with setFilters,
we need to manually trigger the event or it will be omitted.

Sorry, but I don't know how to write a test for this. 