### PR TITLE
Adding two new changers for the sql-support plugin

### DIFF
--- a/src/plugins/sql-support/plugin.js
+++ b/src/plugins/sql-support/plugin.js
@@ -267,7 +267,7 @@ QueryBuilder.extend({
                         });
                     }
 
-                    parts.push(rule.field + ' ' + sql.op.replace(/\?/, value));
+                    parts.push(self.change('getSQLField', rule.field, rule) + ' ' + sql.op.replace(/\?/, value));
                 }
             });
 
@@ -406,12 +406,13 @@ QueryBuilder.extend({
 
                 var left_value = data.left.values.join('.');
 
-                curr.rules.push({
+                var rule = self.change('getSQLRule', {
                     id: self.change('getSQLFieldID', left_value, value),
                     field: left_value,
                     operator: opVal.op,
                     value: opVal.val
                 });
+                curr.rules.push(rule);
             }
         }(parsed.where.conditions, 0));
 


### PR DESCRIPTION
**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/jQuery-QueryBuilder/blob/master/.github/CONTRIBUTING.md)
- [x] I **didn't** commited files in the `dist` directory
- [x] Unit tests are OK
- [x] If it's a new feature, I added the necessary unit tests
- [x] If it's a new language, I filled the `__locale` and `__author` fields

This is a followup to https://github.com/mistic100/jQuery-QueryBuilder/issues/361#issuecomment-248739959. As you say, I am keeping our changes in a separate plugin but I'd like two new change events added to the sql-support plugin since I don't want to maintain a custom copy of it for my plugin. My plugin needs these changers to add its functionality when going back and forth from SQL. Do you think you can add these?

I just migrated these directly from my use-case. I realize it isn't symmetrical (one modifies the whole rule when going from SQL and the other modifies only the field part when going to SQL) but I wanted you hear your thoughts first.