### PR TITLE
Enable focus for AND/OR buttons

### DIFF
--- a/src/scss/default.scss
+++ b/src/scss/default.scss
@@ -63,7 +63,15 @@ $ticks-position: 5px, 10px !default;
     .group-conditions {
       .btn.readonly:not(.active),
       input[name$=_cond] {
-        display: none;
+        border: 0;
+        clip: rect(0 0 0 0);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+        white-space: nowrap;
       }
 
       .btn.readonly {


### PR DESCRIPTION
Accessibility update to replace the default styles for AND/OR group
buttons from `display:none` to the "visuallyhidden" styles from
html5-boilerplate. This fixes keyboard navigation.