### PR TITLE
Move interact from devDependencies to dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,8 @@
     "bootstrap": ">=3.1.0",
     "moment": ">=2.6.0",
     "jquery-extendext": ">=0.1.2",
-    "doT": ">=1.0.3"
+    "doT": ">=1.0.3",
+    "interact": "^1.2.6"
   },
   "devDependencies": {
     "blanket": "^1.1.0",
@@ -26,8 +27,7 @@
     "bootbox": "^4.4.0",
     "awesome-bootstrap-checkbox": "^0.3.0",
     "sql-parser": "^1.1.0",
-    "bind-polyfill": "~1.0.0",
-    "interact": "^1.2.6"
+    "bind-polyfill": "~1.0.0"
   },
   "keywords": [
     "jquery",


### PR DESCRIPTION
**Merge request checklist**

- [-] I read the [guidelines for contributing](https://github.com/mistic100/jQuery-QueryBuilder/blob/master/.github/CONTRIBUTING.md)
- [-] I created my branch from `dev` and I am issuing the PR to `dev`
- [ ] Unit tests are OK
- [ ] If it's a new feature, I added the necessary unit tests
- [ ] If it's a new language, I filled the `__locale` and `__author` fields

I use `Doorman`(https://github.com/mwielgoszewski/doorman).
`Doorman` requires `jQuery-QueryBuilder`(https://github.com/mwielgoszewski/doorman/blob/master/bower.json#L9).

`Doorman` displays the following error.
>interact.js is required to use "sortable" plugin. Get it here: http://interactjs.io

I think this is because `interact` is written in `devDependencies`.
https://github.com/mistic100/jQuery-QueryBuilder/blob/dev/bower.json#L30

If `jQuery-QueryBuilder` is used as library, `interact` will not be installed.
I think that it is better to write `interact` in `dependencies`.

But since I'm not familiar with `bower`, I want you to tell me the right way.
Should it be better for a project like `Doorman` to use `jQuery-QueryBuilder` as a library to write `interact` in `bower.json`?
Thanks.