### PR TITLE
skip validating empty rules

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -529,7 +529,7 @@ $('.reset').on('click', function() {
 $('.parse-json').on('click', function() {
   $('#result').removeClass('hide')
     .find('pre').html(JSON.stringify(
-      $('#builder').queryBuilder('getRules', {get_flags: true}),
+      $('#builder').queryBuilder('getRules', {get_flags: true, skip_empty : true}), 
       undefined, 2
     ));
 });


### PR DESCRIPTION
Related to #426 

This adds an option for `getRules()` to skip empty rules. 

When clicking *add rule*, getting the rules would be impossible, it will always return an empty object (or an invalid one when using `allow_invalid`).
All other rules are now validated, the rule that is empty (did not select an filter or operator) will be removed from the result list and no warning will appear. 

**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/jQuery-QueryBuilder/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [x] Unit tests are OK
- [x] If it's a new feature, I added the necessary unit tests
- [x] If it's a new language, I filled the `__locale` and `__author` fields

I've tried to use QUnit, but it gave me errors out of the box, related to language files. So I'm not able to test a created test. (Not that experienced as well).

In my best attempt, here is the unit test:
```
   /**
     * Test skip_empty option
     */
    QUnit.test('skip_empty', function(assert) {
        $b.queryBuilder({
            filters: basic_filters
        });

        $b.queryBuilder('setRules', {
            condition: 'XOR',
            rules: [{
                id: 'name',
                operator: 'unkown_ope',
                value: 'Mistic'
            },{
               empty : true
            }]
        });

        assert.rulesMatch(
            $b.queryBuilder('getRules', {
                skip_empty: true
            }),
            {
                condition: 'AND',
                rules: [{
                    id: 'name',
                    operator: 'equal',
                    value: 'Mistic'
                }]
            },
            'Should skip empty rules for getRules'
        );
    });
	
```

Seems like the example is conflicting, not necessary to keep my version so just rebase it with whatever you have. 