### PR TITLE
Destroy selectpicker 'beforeDeleteRule'.

### DIFF
--- a/src/plugins/bt-selectpicker/plugin.js
+++ b/src/plugins/bt-selectpicker/plugin.js
@@ -37,6 +37,11 @@ QueryBuilder.define('bt-selectpicker', function(options) {
     this.on('afterUpdateRuleOperator', function(e, rule) {
         rule.$el.find(Selectors.rule_operator).selectpicker('render');
     });
+
+    this.on('beforeDeleteRule', function(e, rule) {
+        rule.$el.find(Selectors.rule_filter).selectpicker('destroy');
+        rule.$el.find(Selectors.rule_operator).selectpicker('destroy');
+    });
 }, {
     container: 'body',
     style: 'btn-inverse btn-xs',


### PR DESCRIPTION
Because it is not destroyed after any rule or group deleted. This improvement covers those two situation. Tests have not been written because other cases had not been covered, too.

**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/jQuery-QueryBuilder/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [x] Unit tests are OK
- [x] If it's a new feature, I added the necessary unit tests
- [x] If it's a new language, I filled the `__locale` and `__author` fields
