### PR TITLE
[fix] ignore case when getting filter by id

### DIFF
--- a/src/plugins/sql-support/plugin.js
+++ b/src/plugins/sql-support/plugin.js
@@ -596,7 +596,7 @@ QueryBuilder.extend(/** @lends module:plugins.SqlSupport.prototype */ {
      */
     getSQLFieldID: function(field, value) {
         var matchingFilters = this.filters.filter(function(filter) {
-            return filter.field === field;
+            return filter.field.toLowerCase() === field.toLowerCase();
         });
 
         var id;


### PR DESCRIPTION
When parsing SQL with upper case column names, it does not match filter IDs with lower case and vice versa. In most cases SQL is case-insensitive and therefore, we ignore cases when getting the filter by ID.

**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/jQuery-QueryBuilder/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [x] Unit tests are OK
- [ ] If it's a new feature, I added the necessary unit tests
- [ ] If it's a new language, I filled the `__locale` and `__author` fields
