### PR TITLE
Fix filter-description plugin not showing button for 'bootbox' option

### DIFF
--- a/src/plugins/filter-description/plugin.js
+++ b/src/plugins/filter-description/plugin.js
@@ -96,6 +96,9 @@ QueryBuilder.define('filter-description', function(options) {
                         bootbox.alert($b.data('description'));
                     });
                 }
+                else {
+                    $b.show();
+                }
 
                 $b.data('description', description);
             }


### PR DESCRIPTION
The 'bootbox' option for the 'filter-description' plugin failed to re-show the button, once hidden.

In my case, I selected a filter with a description field, pressed the down arrow key to select the next filter in the dropdown, which did not contain a description.  I then pressed up arrow key to return to the previous filter with a description, but this time it did now show the filter-description button.

I fixed the code to match the convention of the 'inline' and 'popover' options.