### PR TITLE
Make Utils.defineModelProperties() accessible for plugins

### DIFF
--- a/src/jquery.js
+++ b/src/jquery.js
@@ -72,6 +72,13 @@ $.fn.queryBuilder.define = QueryBuilder.define;
 /**
  * @function
  * @memberof external:"jQuery.fn"
+ * @see Utils.defineModelPropertiesByString
+ */
+$.fn.queryBuilder.defineModelPropertiesByString = Utils.defineModelPropertiesByString;
+
+/**
+ * @function
+ * @memberof external:"jQuery.fn"
  * @see QueryBuilder.regional
  */
 $.fn.queryBuilder.regional = QueryBuilder.regional;

--- a/src/utils.js
+++ b/src/utils.js
@@ -240,3 +240,20 @@ Utils.defineModelProperties = function(obj, fields) {
         });
     });
 };
+
+/**
+ * Defines properties on an Node prototype with getter and setter.<br>
+ *     Update events are emitted in the setter through root Model (if any).<br>
+ *     The object must have a `__` object, non enumerable property to store values.
+ * @param {string} modelName
+ *   one of Model, Node, Group, Rule
+ * @param {string[]} fields
+ */
+Utils.defineModelPropertiesByString = function(modelName, fields) {
+    // Allowing eval here only because the allowed values are very strict
+    if (['Model', 'Node', 'Group', 'Rule'].indexOf(modelName) !== -1) {
+        /*jshint evil:true */
+        var obj = eval(modelName);
+        return Utils.defineModelProperties(obj, fields);
+    }
+};


### PR DESCRIPTION
For Standalone Plugins it is not possible to extend existing models. While the main defineModelProperties could be copied, its not possible to get the object itself.

This proposed PR is adding a new method and exposes it, which makes it possible for standalone plugins to add properties to models.

This is done as we do not want to add all dependencies to build the querybuilder to be added to our build environment and want to keep using a standalone plugin. Just makes our life easier ;)

Our plugin is from the UI standpoint very similar to the not-group plugin. Only thing I needed to copy now is some selectors (also not public), but I couldn't work around not being able to add the property to the group model.

If there are ideas how this can be done differently, I'm open for suggestions and would change the PR.

**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/jQuery-QueryBuilder/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [x] Unit tests are OK
- [x] If it's a new feature, I added the necessary unit tests
- [x] If it's a new language, I filled the `__locale` and `__author` fields
