### PR TITLE
Added support to compile using Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:5
+
+RUN npm install -g grunt-cli bower
+
+WORKDIR /opt/querybuilder
+ADD package.json bower.json /opt/querybuilder/
+RUN npm install && bower install --allow-root
+
+ADD . /opt/querybuilder
+
+ENTRYPOINT ["grunt", "test", "default"]

--- a/README.md
+++ b/README.md
@@ -90,7 +90,14 @@ grunt --languages=fr,it
  * `grunt serve` to open the example page with automatic build and livereload.
  * `grunt doc` to generate the documentation.
 
+#### Build using Docker
 
+In case docker is available following commands can be used to build.
+
+* `docker build . -t querybuilder` to create the base image (needs to be called only once or on package/bower.json changes)
+* `docker run --rm -iv$PWD/dist:/opt/querybuilder/dist -v$PWD/src:/opt/querybuilder/src querybuilder` to build the 
+
+Its possible to just add explained options to the end of the docker run command.
 
 ## License
 This library is available under the MIT license.


### PR DESCRIPTION
While working on #608 I needed a way to run unit tests and build the lib.

On my working machine I didn't wanted to install grunt-cli and bower.

Because I'm a big fan of Docker I created a Dockerfile and minor documentation in the README how to use it.

Just wanted to share this as I did this now anyway.

After running the commands, the compiled output is created under dist like grunt would do it normally. You just do not have the other folder hanging around like node_modules, ect.

**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/jQuery-QueryBuilder/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [x] Unit tests are OK
- [ ] If it's a new feature, I added the necessary unit tests
- [ ] If it's a new language, I filled the `__locale` and `__author` fields
