### PR TITLE
Fixing when node has an error visible and the operations shows inputs…

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -753,9 +753,9 @@ QueryBuilder.prototype.updateRuleOperator = function(rule, previousOperator) {
 
     if (!rule.operator || rule.operator.nb_inputs === 0) {
 
-        if(rule.__.error){
+        if (rule.__.error) {
             rule.__.error = null;
-            rule.$el.removeClass("has-error");
+            rule.$el.removeClass('has-error');
         }
 
         $valueContainer.hide();

--- a/src/core.js
+++ b/src/core.js
@@ -752,6 +752,12 @@ QueryBuilder.prototype.updateRuleOperator = function(rule, previousOperator) {
     var $valueContainer = rule.$el.find(QueryBuilder.selectors.value_container);
 
     if (!rule.operator || rule.operator.nb_inputs === 0) {
+
+        if(rule.__.error){
+            rule.__.error = null;
+            rule.$el.removeClass("has-error");
+        }
+
         $valueContainer.hide();
 
         rule.__.value = undefined;


### PR DESCRIPTION
… if user select an operation with no inputs (like "is empty/is not empty", "is null/is not null") error keeps showing when it should disappear

I detect this issue using version 2.4.5 of jQuery QueryBuilder. Maybe this is not the best way of do this, but it works for my project.

**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/jQuery-QueryBuilder/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [x] Unit tests are OK
- [ ] If it's a new feature, I added the necessary unit tests
- [ ] If it's a new language, I filled the `__locale` and `__author` fields
