### PR TITLE
afterUpdateRuleValue trigger chosen:update

### DIFF
--- a/src/plugins/chosen-selectpicker/plugin.js
+++ b/src/plugins/chosen-selectpicker/plugin.js
@@ -34,6 +34,10 @@ QueryBuilder.define('chosen-selectpicker', function(options) {
     this.on('afterUpdateRuleOperator', function(e, rule) {
         rule.$el.find(Selectors.rule_operator).trigger('chosen:updated');
     });
+    
+    this.on('afterUpdateRuleValue', function (e, rule) {
+        rule.$el.find(Selectors.rule_value).trigger('chosen:updated');
+    });
 
     this.on('beforeDeleteRule', function(e, rule) {
         rule.$el.find(Selectors.rule_filter).chosen('destroy');


### PR DESCRIPTION
When i load my rules from the database chosen doesn't set the value of my rules. Adding the missing afterUpdateRuleValue to trigger chosen:updated like also workes for the filter and operator fixes this problem.

**Merge request checklist**

- [ ] I read the [guidelines for contributing](https://github.com/mistic100/jQuery-QueryBuilder/blob/master/.github/CONTRIBUTING.md)
- [ ] I created my branch from `dev` and I am issuing the PR to `dev`
- [ ] I didn't pushed the `dist` directory
- [ ] Unit tests are OK
- [ ] If it's a new feature, I added the necessary unit tests
- [ ] If it's a new language, I filled the `__locale` and `__author` fields
