### PR TITLE
Fix memory leak when calling `.destroy`

### DIFF
--- a/src/public.js
+++ b/src/public.js
@@ -23,6 +23,16 @@ QueryBuilder.prototype.destroy = function() {
         .removeData('queryBuilder');
 
     delete this.$el[0].queryBuilder;
+
+    // clear properties to reduce memory footprint
+    this.filters = null;
+    this.settings = null;
+    this.plugins = null;
+    this.templates = null;
+    this.operators = null;
+    this.lang = null;
+    this.icons = null;
+    this.status = null;
 };
 
 /**


### PR DESCRIPTION
Creating a query builder, loading it with data, then destroying it was
causing some memory to be retained in the browser.

This should fix.

This fix was created by my colleague w/ @claudior2184 .

**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/jQuery-QueryBuilder/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [x] I didn't pushed the `dist` directory
- [x] Unit tests are OK
- [x] If it's a new feature, I added the necessary unit tests
- [x] If it's a new language, I filled the `__locale` and `__author` fields
