### PR TITLE
Feature: add source map for easier debugging

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -243,7 +243,8 @@ module.exports = function(grunt) {
         uglify: {
             options: {
                 banner: '<%= banner %>\n',
-                mangle: { reserved: ['$'] }
+                mangle: { reserved: ['$'] },
+                sourceMap: true,
             },
             dist: {
                 files: [{


### PR DESCRIPTION
I found that having source map file (`.map`) makes it way easier to debug errors raised from QueryBuilder when using the minified version of the release. This PR simply uses the [`sourceMap` option of uglify][1] to generate the source map files in the `dist/` directory which can then be used by developers if they wish to.

[1]: https://github.com/gruntjs/grunt-contrib-uglify#sourcemap

---

**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/jQuery-QueryBuilder/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [x] I didn't pushed the `dist` directory
- [ ] Unit tests are OK
- [x] If it's a new feature, I added the necessary unit tests
- [x] If it's a new language, I filled the `__locale` and `__author` fields
