### PR TITLE
New 'close' button

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -33,5 +33,6 @@
     "catch"
   ],
   "requireEarlyReturn": false,
-  "validateCommentPosition": false
+  "validateCommentPosition": false,
+  "validateLineBreaks": null
 }

--- a/src/core.js
+++ b/src/core.js
@@ -264,6 +264,14 @@ QueryBuilder.prototype.bindEvents = function() {
         });
     }
 
+    if (this.settings.allow_close == 1) {
+        // delete builder button
+        this.$el.on('click.queryBuilder', Selectors.close_builder, function() {
+            var $querybuilder = $(this).closest(Selectors.query_builder);
+            $querybuilder.queryBuilder('destroy');
+        });
+    }
+
     // model events
     this.model.on({
         'drop': function(e, node) {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -40,7 +40,8 @@ QueryBuilder.modifiable_options = [
     'allow_groups',
     'allow_empty',
     'default_condition',
-    'default_filter'
+    'default_filter',
+    'allow_close'
 ];
 
 /**
@@ -49,6 +50,7 @@ QueryBuilder.modifiable_options = [
  * @readonly
  */
 QueryBuilder.selectors = {
+    query_builder:        '.query-builder',
     group_container:      '.rules-group-container',
     rule_container:       '.rule-container',
     filter_container:     '.rule-filter-container',
@@ -72,7 +74,8 @@ QueryBuilder.selectors = {
     add_rule:             '[data-add=rule]',
     delete_rule:          '[data-delete=rule]',
     add_group:            '[data-add=group]',
-    delete_group:         '[data-delete=group]'
+    delete_group:         '[data-delete=group]',
+    close_builder:        '[data-delete=builder]'
 };
 
 /**
@@ -130,6 +133,7 @@ QueryBuilder.DEFAULTS = {
     display_errors: true,
     allow_groups: -1,
     allow_empty: false,
+    allow_close: false,
     conditions: ['AND', 'OR'],
     default_condition: 'AND',
     inputs_separator: ' , ',

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -6,6 +6,7 @@
   "add_group": "Add group",
   "delete_rule": "Delete",
   "delete_group": "Delete",
+  "close_builder": "Close",
 
   "conditions": {
     "AND": "AND",

--- a/src/template.js
+++ b/src/template.js
@@ -15,6 +15,11 @@ QueryBuilder.templates.group = '\
           <i class="{{= it.icons.remove_group }}"></i> {{= it.translate("delete_group") }} \
         </button> \
       {{?}} \
+      {{? it.settings.allow_close && it.level==1 }} \
+      <button type="button" class="btn btn-xs btn-danger" data-delete="builder"> \
+        <i class="{{= it.icons.close_builder}}"></i> {{= it.translate("close_builder") }} \
+      </button> \
+      {{?}} \
     </div> \
     <div class="btn-group group-conditions"> \
       {{~ it.conditions: condition }} \


### PR DESCRIPTION
Added ability to enable a 'close' button for individual queryBuilder instances.

**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/jQuery-QueryBuilder/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [x] I didn't pushed the `dist` directory
- [x] Unit tests are OK
- [ ] If it's a new feature, I added the necessary unit tests
- [ ] If it's a new language, I filled the `__locale` and `__author` fields

** Test output: **
Running "qunit:all" (qunit) task
Testing http://localhost:9001/tests/index.html?coverage=true&noglobals=true ..........................................................>> LCOV file created
OK
>> 58 tests completed with 0 failed, 0 skipped, and 0 todo.
>> 200 assertions (in 2910ms), passed: 200, failed: 0

Done.