### PR TITLE
Add support to read only state.

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -37,6 +37,7 @@ QueryBuilder.inputs = [
  */
 QueryBuilder.modifiable_options = [
     'display_errors',
+    'read_only',
     'allow_groups',
     'allow_empty',
     'default_condition',
@@ -128,6 +129,7 @@ QueryBuilder.DEFAULTS = {
 
     sort_filters: false,
     display_errors: true,
+    read_only: false,
     allow_groups: -1,
     allow_empty: false,
     conditions: ['AND', 'OR'],

--- a/src/main.js
+++ b/src/main.js
@@ -136,6 +136,12 @@ var QueryBuilder = function($el, options) {
     // INIT
     this.$el.addClass('query-builder form-inline');
 
+    // if read only, add readonly class
+    if (this.settings.read_only)
+    {
+        this.$el.addClass('query-builder-readonly');
+    }
+
     this.filters = this.checkFilters(this.filters);
     this.operators = this.checkOperators(this.operators);
     this.bindEvents();

--- a/src/public.js
+++ b/src/public.js
@@ -19,7 +19,7 @@ QueryBuilder.prototype.destroy = function() {
 
     this.$el
         .off('.queryBuilder')
-        .removeClass('query-builder')
+        .removeClass('query-builder query-builder-readonly')
         .removeData('queryBuilder');
 
     delete this.$el[0].queryBuilder;
@@ -105,6 +105,14 @@ QueryBuilder.prototype.setOptions = function(options) {
     $.each(options, function(opt, value) {
         if (QueryBuilder.modifiable_options.indexOf(opt) !== -1) {
             this.settings[opt] = value;
+            if (opt === 'read_only')
+            {
+                this.$el.removeClass('query-builder-readonly');
+                if (value)
+                {
+                    this.$el.addClass('query-builder-readonly');
+                }
+            }
         }
     }.bind(this));
 };

--- a/src/scss/default.scss
+++ b/src/scss/default.scss
@@ -172,5 +172,11 @@ $ticks-position: 5px, 10px !default;
   }
 }
 
+// READ ONLY
+.query-builder-readonly > div {
+  opacity: .5;
+  pointer-events: none;
+}
+
 // import
 // endimport


### PR DESCRIPTION
**Merge request checklist**

- [ X ] I read the [guidelines for contributing](https://github.com/mistic100/jQuery-QueryBuilder/blob/master/.github/CONTRIBUTING.md)
- [ X ] I created my branch from `dev` and I am issuing the PR to `dev`
- [ X ] I didn't pushed the `dist` directory
- [ X ] Unit tests are OK
- [ X ] If it's a new feature, I added the necessary unit tests
- [ X ] If it's a new language, I filled the `__locale` and `__author` fields

**Pull request summary**

This pull request add "read_only" option support to jQuery QueryBuilder core. This option could be changed with "setOptions" call.
When set true, the query will be set read only with a simple overlay. It'll use CSS [pointer-events](https://caniuse.com/#feat=pointer-events). It's compatible with all browsers except "Opera Mini".
If you think it will fit better as a plugin, please let me know on this request, than I'll request another push with a plugin code.