### PR TITLE
Fixed Unexpected 'NUMBER'

### DIFF
--- a/src/plugins/sql-support/plugin.js
+++ b/src/plugins/sql-support/plugin.js
@@ -214,7 +214,7 @@ QueryBuilder.defaults({
         'named': function(values, char) {
             if (!char || char.length > 1) char = ':';
             var regex1 = new RegExp('^\\' + char);
-            var regex2 = new RegExp('\\' + char + '(' + Object.keys(values).join('|') + ')', 'g');
+            var regex2 = new RegExp('\\' + char + '(' + Object.keys(values).join('|') + ')\\b', 'g');
             return {
                 parse: function(v) {
                     return regex1.test(v) ? values[v.slice(1)] : v;


### PR DESCRIPTION
if you had a query with an "IN" with 10 elements or more, the regex of setRulesFromSQL did not match correctly

**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/jQuery-QueryBuilder/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [x] I didn't pushed the `dist` directory
- [x] Unit tests are OK
- [x] If it's a new feature, I added the necessary unit tests
- [x] If it's a new language, I filled the `__locale` and `__author` fields
