### PR TITLE
Fix filter plugin select2 whitespace error.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -700,7 +700,7 @@ QueryBuilder.prototype.createRuleInput = function(rule) {
     var filter = rule.filter;
 
     for (var i = 0; i < rule.operator.nb_inputs; i++) {
-        var $ruleInput = $($.parseHTML(this.getRuleInput(rule, i)));
+        var $ruleInput = $($.parseHTML($.trim(this.getRuleInput(rule, i))));
         if (i > 0) $valueContainer.append(this.settings.inputs_separator);
         $valueContainer.append($ruleInput);
         $inputs = $inputs.add($ruleInput);


### PR DESCRIPTION
**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/jQuery-QueryBuilder/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [x] I didn't pushed the `dist` directory
- [ ] Unit tests are OK
- [ ] If it's a new feature, I added the necessary unit tests
- [ ] If it's a new language, I filled the `__locale` and `__author` fields
