### PR TITLE
Fix i18n wrapper to support CommonJS that was forgotten in d552fde

### DIFF
--- a/src/i18n/.wrapper.js
+++ b/src/i18n/.wrapper.js
@@ -1,8 +1,9 @@
 (function(root, factory) {
     if (typeof define == 'function' && define.amd) {
-        define(['jquery', 'query-builder'], factory);
-    }
-    else {
+        define(['jquery'], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory(require('jquery'));
+    } else {
         factory(root.jQuery);
     }
 }(this, function($) {


### PR DESCRIPTION
The i18n `.wrapper.js` was not updated to support CommonJS in d552fde. Without you can't import a translation file in a CommonJS environment.

**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/jQuery-QueryBuilder/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [x] I didn't pushed the `dist` directory
- [x] Unit tests are OK
- [ ] If it's a new feature, I added the necessary unit tests
- [ ] If it's a new language, I filled the `__locale` and `__author` fields
